### PR TITLE
Added methods to mock inputs to the serial port

### DIFF
--- a/t/test_mocked_port.t
+++ b/t/test_mocked_port.t
@@ -1,0 +1,25 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+BEGIN { use_ok('Test::Device::SerialPort') };
+
+my $port = Test::Device::SerialPort->new;
+
+$port->mock_port(1);
+$port->mock_messages('abc', 'def');
+
+is_deeply [$port->read(1)], [1,'a'],
+    'Read one character off the mocked port';
+is_deeply [$port->read(3)], [3,'bcd'],
+    'Read three more characters';
+
+is_deeply [$port->read(5)], [2,'ef'],
+    'Read the rest of the characters';
+
+is_deeply [$port->read(3)], [0, ''],
+    'Empty buffer returns 0 bytes and a null character';
+
+done_testing();


### PR DESCRIPTION
Hi,

I have added a couple of methods to the Test::Device::SerialPort object which allow for adding test strings and to "read" them back as if they came from the serial port. This branch also adds a test file and a brief description in the documentation.

What do you think? Would you be interested in merging these changes into the master and in future CPAN releases?

Thank you and best regards,

Julio
